### PR TITLE
feat: Add option to define what separator to use'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,8 @@ There are no known issues at this time. If you encounter any problems, please op
 1.0.0
 Initial release of File Path Commenter.
 
-1.2.0
+1.1.0
 Added customizable include paths feature.
+
+1.2.0
+Added customizable separator feature.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ No additional requirements or dependencies are needed for this extension.
 
 This extension contributes the following settings:
 
-- `filePathCommenter.includePaths`: An array of paths to include for file path comments. Paths are relative to the workspace root.
+- `filePathCommenter.includePaths`: (Default: `["src"]`) - An array of paths to include for file path comments. Paths are relative to the workspace root .
+- `filePathCommenter.pathSeparator`: (Default: `"auto"`) - A string to define what separator to use: 
+    - `"auto"` - (use OS separator, `/` for Unix-based systems, `\` for Windows), 
+    - `"forward"` - (`/`)
+    - `"backward"` - (`\`).
 
 By default, only files in the "src" folder will have comments added. You can customize this behavior in your VS Code settings.
 
@@ -36,8 +40,22 @@ By default, only files in the "src" folder will have comments added. You can cus
   "filePathCommenter.includePaths": ["src", "tests", "lib"]
 }
 ```
-
 This configuration will add file path comments to files in the "src", "tests", and "lib" directories and their subdirectories.
+
+### How to Customize Separator
+
+1. Open VS Code Settings (File > Preferences > Settings)
+2. Search for "File Path Commenter"
+3. Find the "Separator" setting
+4. Click on "Edit in settings.json"
+5. Add or modify the `filePathCommenter.pathSeparator` string. For example:
+
+```json
+{
+  "filePathCommenter.pathSeparator": "forward"
+}
+```
+
 
 ## Known Issues
 
@@ -48,5 +66,5 @@ There are no known issues at this time. If you encounter any problems, please op
 1.0.0
 Initial release of File Path Commenter.
 
-1.1.0
+1.2.0
 Added customizable include paths feature.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "file-path-commenter",
   "displayName": "File Path Commenter",
   "description": "Effortlessly add relative file path comments to the top of your code files with the File Path Commenter extension for Visual Studio Code. This extension is designed to enhance your workflow, especially when leveraging large language models (LLMs) such as ChatGPT, Claude, and other AI assistants to write and manage your code.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.91.0"
   },
@@ -56,6 +56,12 @@
             "type": "string"
           },
           "description": "Array of paths to include for file path comments. Paths are relative to the workspace root."
+        },
+        "filePathCommenter.pathSeparator": {
+          "type": "string",
+          "default": "auto",
+          "enum": ["auto", "forward", "backward"],
+          "description": "Path separator to use in comments: auto (system default), forward (/), or backward (\\)."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+// src\extension.ts
 import * as vscode from 'vscode';
 import * as path from 'path';
 
@@ -59,6 +60,7 @@ function isFileInIncludedPaths(filePath: string, workspacePath: string): boolean
 }
 
 async function addRelativePathComment(document: vscode.TextDocument) {
+
 	console.log(`Checking file: ${document.fileName}`);
 	outputChannel.appendLine(`Checking file: ${document.fileName}`);
 
@@ -85,9 +87,29 @@ async function addRelativePathComment(document: vscode.TextDocument) {
 
     console.log(`Attempting to add/update comment in: ${document.fileName}`);
     outputChannel.appendLine(`Attempting to add/update comment in: ${document.fileName}`);
+    
+	const config = vscode.workspace.getConfiguration('filePathCommenter');
+    const pathSeparatorSetting = config.get<string>('pathSeparator') || 'auto';
+    let pathSeparator: string;
 
-    const relativePath = path.relative(workspaceFolder.uri.fsPath, document.fileName);
-    const newComment = `${commentSyntax}${relativePath}${commentClosingSyntax}`;
+	switch (pathSeparatorSetting) {
+        case 'forward':
+            pathSeparator = '/';
+            break;
+        case 'backward':
+            pathSeparator = '\\';
+            break;
+        default: // 'auto'
+            pathSeparator = path.sep; // Use the system's default
+            break;
+    }
+
+	let relativePath = path.relative(workspaceFolder.uri.fsPath, document.fileName);
+
+	if (pathSeparator !== path.sep) {
+		relativePath = relativePath.split(path.sep).join(pathSeparator);
+	}
+	const newComment = `${commentSyntax}${relativePath}${commentClosingSyntax}`;
 
 	try {
 		const editor = await vscode.window.showTextDocument(document);


### PR DESCRIPTION
This pull request adds a `filePathCommenter.pathSeparator` setting to control the path separator used in file path comments.

**Motivation:**

Some users prefer a consistent path style in their comments, regardless of the operating system they are using. This change allows them to enforce either forward slashes or backslashes.

**Implementation:**

*   A new configuration setting `filePathCommenter.pathSeparator` has been added to `package.json`.
*   The `addRelativePathComment` function has been modified to read this setting.
*   A `switch` statement handles the different setting values ('auto', 'forward', 'backward').
*   Critically, the relative path is normalized using `split(path.sep).join(pathSeparator)` to ensure correct path separators are used, regardless of the operating system running VS Code.

This change addresses potential cross-platform inconsistencies and enhances user customization.